### PR TITLE
fix: handle float64/int type mismatch for priority and order parameters

### DIFF
--- a/pkg/todoist/tasks.go
+++ b/pkg/todoist/tasks.go
@@ -272,8 +272,8 @@ func (tp *ToolProvider) HandleCreateTask(ctx context.Context, request *mcp.CallT
 	description, _ := OptionalParam[string](request, "description")
 	projectID, _ := OptionalParam[string](request, "projectId")
 	parentID, _ := OptionalParam[string](request, "parentId")
-	order, _ := OptionalParam[int](request, "order")
-	priority, _ := OptionalParam[int](request, "priority")
+	order, _ := OptionalIntParam(request, "order")
+	priority, _ := OptionalIntParam(request, "priority")
 	dueString, _ := OptionalParam[string](request, "dueString")
 	dueDate, _ := OptionalParam[string](request, "dueDate")
 	dueDatetime, _ := OptionalParam[string](request, "dueDatetime")
@@ -384,7 +384,7 @@ func (tp *ToolProvider) HandleUpdateTask(ctx context.Context, request *mcp.CallT
 
 	content, _ := OptionalParam[string](request, "content")
 	description, _ := OptionalParam[string](request, "description")
-	priority, _ := OptionalParam[int](request, "priority")
+	priority, _ := OptionalIntParam(request, "priority")
 	dueString, _ := OptionalParam[string](request, "dueString")
 	dueDate, _ := OptionalParam[string](request, "dueDate")
 	dueDatetime, _ := OptionalParam[string](request, "dueDatetime")
@@ -567,6 +567,30 @@ func OptionalParam[T any](r *mcp.CallToolRequest, p string) (T, error) {
 	}
 
 	return args[p].(T), nil
+}
+
+// OptionalIntParam is a helper function that fetches an integer parameter from the request.
+// JSON numbers are always float64 after json.Unmarshal, so this handles both float64 and int.
+func OptionalIntParam(r *mcp.CallToolRequest, p string) (int, error) {
+	args, err := getArguments(r)
+	if err != nil {
+		return 0, err
+	}
+
+	if _, ok := args[p]; !ok {
+		return 0, nil
+	}
+
+	switch v := args[p].(type) {
+	case float64:
+		return int(v), nil
+	case int:
+		return v, nil
+	case nil:
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("parameter %s is not a number", p)
+	}
 }
 
 // OptionalStringArrayParam is a helper function that can be used to fetch a requested parameter from the request.

--- a/pkg/todoist/tasks_test.go
+++ b/pkg/todoist/tasks_test.go
@@ -995,3 +995,65 @@ func TestOptionalStringArrayParam(t *testing.T) {
 		})
 	}
 }
+
+func TestOptionalIntParam(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   map[string]interface{}
+		paramKey string
+		want     int
+		wantErr  bool
+	}{
+		{
+			name:     "float64 value (JSON number)",
+			params:   map[string]interface{}{"priority": float64(4)},
+			paramKey: "priority",
+			want:     4,
+			wantErr:  false,
+		},
+		{
+			name:     "int value",
+			params:   map[string]interface{}{"priority": int(2)},
+			paramKey: "priority",
+			want:     2,
+			wantErr:  false,
+		},
+		{
+			name:     "parameter does not exist",
+			params:   map[string]interface{}{},
+			paramKey: "priority",
+			want:     0,
+			wantErr:  false,
+		},
+		{
+			name:     "nil value",
+			params:   map[string]interface{}{"priority": nil},
+			paramKey: "priority",
+			want:     0,
+			wantErr:  false,
+		},
+		{
+			name:     "wrong type",
+			params:   map[string]interface{}{"priority": "urgent"},
+			paramKey: "priority",
+			want:     0,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := MockCallToolRequest(tt.params)
+
+			got, err := OptionalIntParam(req, tt.paramKey)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #57

The `priority` and `order` parameters in `todoist_create_task` and `todoist_update_task` were silently ignored, causing tasks to always be created with default priority regardless of the value passed.

## Root Cause

`getArguments` deserializes `r.Params.Arguments` via `json.Unmarshal` into `map[string]interface{}`. Go's `encoding/json` always represents JSON numbers as `float64` in this case. The subsequent `.(int)` type assertion in `OptionalParam[int]` always fails, and since the error is discarded with `_`, `priority` and `order` always fall back to `0` and are never sent to the Todoist API.

## Changes

- Add `OptionalIntParam` helper that accepts both `float64` (JSON-decoded) and `int` values
- Replace `OptionalParam[int]` with `OptionalIntParam` for `priority` and `order` in `HandleCreateTask` and `HandleUpdateTask`
- Add `TestOptionalIntParam` with 5 test cases covering float64, int, missing, nil, and wrong-type inputs

## Note on Secondary Issue

Issue #57 also reported a priority scale inversion. This is **not present in the current code** — the tool description already correctly states `1 (normal) … 4 (urgent)`, which matches the Todoist API convention. No conversion layer is needed.

## Test Plan

- [ ] `go test ./pkg/todoist/...` passes
- [ ] `TestOptionalIntParam` covers all input types (float64, int, missing, nil, wrong type)
- [ ] Manually verify that `todoist_create_task` with `priority: 4` creates a P1 (urgent) task